### PR TITLE
Fix CGFloat error

### DIFF
--- a/TWRDownloadManager.h
+++ b/TWRDownloadManager.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface TWRDownloadManager : NSObject
 

--- a/TWRDownloadManager.h
+++ b/TWRDownloadManager.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 @interface TWRDownloadManager : NSObject
 

--- a/TWRDownloadObject.h
+++ b/TWRDownloadObject.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef void(^TWRDownloadRemainingTimeBlock)(NSUInteger seconds);
 typedef void(^TWRDownloadProgressBlock)(CGFloat progress);

--- a/TWRDownloadObject.h
+++ b/TWRDownloadObject.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
+#import <CoreGraphics/CoreGraphics.h>
 
 typedef void(^TWRDownloadRemainingTimeBlock)(NSUInteger seconds);
 typedef void(^TWRDownloadProgressBlock)(CGFloat progress);


### PR DESCRIPTION
Specifically import UIKit so that CGFloat is recognized by the library.