### PR TITLE
Handling connection failures

### DIFF
--- a/TWRDownloadManager.h
+++ b/TWRDownloadManager.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <CoreGraphics/CoreGraphics.h>
 
 @interface TWRDownloadManager : NSObject
 

--- a/TWRDownloadManager.m
+++ b/TWRDownloadManager.m
@@ -238,7 +238,7 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
     
     if (download.completionBlock) {
         dispatch_async(dispatch_get_main_queue(), ^(void) {
-            download.completionBlock(YES);
+            download.completionBlock(!error);
         });
     }
     

--- a/TWRDownloadManager.m
+++ b/TWRDownloadManager.m
@@ -246,6 +246,22 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
     [self.downloads removeObjectForKey:fileIdentifier];
 }
 
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+    NSString *fileIdentifier = task.originalRequest.URL.absoluteString;
+    TWRDownloadObject *download = [self.downloads objectForKey:fileIdentifier];
+    if (error) {
+        if (download.completionBlock) {
+            dispatch_async(dispatch_get_main_queue(), ^(void) {
+                download.completionBlock(!error);
+            });
+        }
+        
+        // remove object from the download
+        [self.downloads removeObjectForKey:fileIdentifier];
+    }
+}
+
 - (CGFloat)remainingTimeForDownload:(TWRDownloadObject *)download
                    bytesTransferred:(int64_t)bytesTransferred
           totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {

--- a/TWRDownloadObject.h
+++ b/TWRDownloadObject.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <CoreGraphics/CoreGraphics.h>
 
 typedef void(^TWRDownloadRemainingTimeBlock)(NSUInteger seconds);
 typedef void(^TWRDownloadProgressBlock)(CGFloat progress);


### PR DESCRIPTION
If the download fails due to loss of Wifi, we should remove the item from the queue and return the completion block with a "NO".